### PR TITLE
Update build-extras.gradle

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,3 +1,3 @@
-if (!project.hasProperty('cdvCompileSdkVersion') || cdvCompileSdkVersion < 33) {
-    ext.cdvCompileSdkVersion = 33;
+if (!project.hasProperty('cdvCompileSdkVersion') || cdvCompileSdkVersion < 34) {
+    ext.cdvCompileSdkVersion = 34;
 }


### PR DESCRIPTION
Upgrading the Android API level from 33 to 34 to support the Outsystems MABS 10.0 build service.